### PR TITLE
Libify tlparse, first steps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -105,9 +105,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.2"
+version = "4.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
+checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -127,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.0"
+version = "4.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -221,9 +221,9 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "html-escape"
@@ -430,9 +430,9 @@ checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "tlparse"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "base16ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,17 @@
 [package]
 name = "tlparse"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 authors = ["Edward Z. Yang <ezyang@mit.edu>"]
 description = "Parse TORCH_LOG logs produced by PyTorch torch.compile"
 license = "BSD-3-Clause"
+
+[lib]
+name = "tlparse"
+
+[[bin]]
+name = "tlparse"
+path = "src/cli.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,64 @@
+use clap::Parser;
+
+use std::fs;
+use std::path::PathBuf;
+
+use tlparse::{ParseConfig, parse_path};
+
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+#[command(propagate_version = true)]
+pub struct Cli {
+    path: PathBuf,
+    /// Output directory, defaults to `tl_out`
+    #[arg(short, default_value = "tl_out")]
+    out: PathBuf,
+    /// Delete out directory if it already exists
+    #[arg(long)]
+    overwrite: bool,
+    /// Return non-zero exit code if unrecognized log lines are found.  Mostly useful for unit
+    /// testing.
+    #[arg(long)]
+    strict: bool,
+    /// Don't open browser at the end
+    #[arg(long)]
+    no_browser: bool,
+}
+
+
+fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    let path = cli.path;
+    let out_path = cli.out;
+
+    if out_path.exists() {
+        if !cli.overwrite {
+            panic!(
+                "{} already exists, pass --overwrite to overwrite",
+                out_path.display()
+            );
+        }
+        fs::remove_dir_all(&out_path)?;
+    }
+    fs::create_dir(&out_path)?;
+
+    let config = ParseConfig {
+        strict: cli.strict,
+    };
+
+    let output = parse_path(&path, config)?;
+
+    for (filename, path) in output {
+        let out_file = out_path.join(filename);
+        if let Some(dir) = out_file.parent() {
+            fs::create_dir_all(dir)?;
+        }
+        fs::write(out_file, path)?;
+    }
+
+    if !cli.no_browser {
+        opener::open(out_path.join("index.html"))?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
- Ran clippy on the files for a quick lint
- Decoupled some of the CLI from the library. The only part that's still a bit tangled up is the spinner, but I'll deal with that later 
- Defined a lib.rs, deleted the Cargo.lock file that's generated and added to gitignore. Building the binary (with `cargo run` or `cargo build --bin tlparse`) still results in an executable binary, but the library is now the main crate. 

TODO: need to test what happens with pip and cargo install