### PR TITLE
Generalize structured log parsers

### DIFF
--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -1,0 +1,93 @@
+use crate::types::*;
+use std::path::PathBuf;
+
+pub trait StructuredLogParser {
+    // If this returns Some value, the parser will be run on that metadata.
+    // Otherwise, it will be skipped
+
+    // 'e is the lifetime of the envelope
+    fn get_metadata<'e>(&self, e: &'e Envelope) -> Option<Metadata<'e>>;
+    fn parse<'e>(&self,
+        lineno: usize,
+        metadata: Metadata<'e>,
+        rank: Option<u32>,
+        compile_id: &Option<CompileId>,
+        payload: &str
+    ) -> anyhow::Result<ParseOutput>;
+}
+
+// Takes a filename and a payload and writes that payload into a the file
+fn simple_file_output(
+    filename: &str,
+    lineno: usize,
+    compile_id: &Option<CompileId>,
+    payload: &str
+) -> anyhow::Result<ParseOutput> {
+    let compile_id_dir: PathBuf = compile_id
+    .as_ref()
+    .map_or(
+        format!("unknown_{lineno}"),
+        |CompileId {
+             frame_id,
+             frame_compile_id,
+             attempt,
+         }| { format!("{frame_id}_{frame_compile_id}_{attempt}") },
+    )
+    .into();
+    let subdir = PathBuf::from(compile_id_dir);
+    let f = subdir.join(filename);
+    Ok(Vec::from([(f, String::from(payload))]))
+}
+
+pub struct SentinelFileParser {
+    filename: &'static str,
+    get_sentinel: fn (&Envelope) -> Option<&EmptyMetadata>,
+} impl SentinelFileParser {
+    pub fn new(filename: &'static str, get_sentinel: fn (&Envelope) -> Option<&EmptyMetadata>) -> Self {
+        Self { filename, get_sentinel }
+    }
+}
+impl StructuredLogParser for SentinelFileParser {
+    fn get_metadata<'e>(&self, e: &'e Envelope) -> Option<Metadata<'e>> {
+        (self.get_sentinel)(e).map(|m| Metadata::Empty(m))
+    }
+    fn parse<'e>(&self,
+            lineno: usize,
+            _metadata: Metadata<'e>,
+            _rank: Option<u32>,
+            compile_id: &Option<CompileId>,
+            payload: &str
+    ) -> anyhow::Result<ParseOutput> {
+        simple_file_output(self.filename, lineno, compile_id, payload)
+    }
+}
+// Same as above, but can log the size of the graph
+pub struct DynamoOutputGraphParser;
+impl StructuredLogParser for DynamoOutputGraphParser {
+    fn get_metadata<'e>(&self, e: &'e Envelope) -> Option<Metadata<'e>> {
+        e.dynamo_output_graph.as_ref().map(|m| Metadata::DynamoOutputGraph(m))
+    }
+    fn parse<'e>(&self,
+            lineno: usize,
+            _metadata: Metadata<'e>, // TODO: log size of graph
+            _rank: Option<u32>,
+            compile_id: &Option<CompileId>,
+            payload: &str
+    ) -> anyhow::Result<ParseOutput> {
+        simple_file_output("dynamo_output_graph.txt", lineno, compile_id, payload)
+    }
+}
+
+// Register your parser here
+pub fn all_parsers() -> Vec<Box<dyn StructuredLogParser>> {
+    let result : Vec<Box<dyn StructuredLogParser>> = vec![
+        Box::new(SentinelFileParser::new("optimize_ddp_split_graph.txt", |e| e.optimize_ddp_split_graph.as_ref())),
+        Box::new(SentinelFileParser::new("compiled_autograd_graph.txt", |e| e.compiled_autograd_graph.as_ref())),
+        Box::new(SentinelFileParser::new("aot_forward_graph.txt", |e| e.aot_forward_graph.as_ref())),
+        Box::new(SentinelFileParser::new("aot_backward_graph.txt", |e| e.aot_backward_graph.as_ref())),
+        Box::new(SentinelFileParser::new("aot_joint_graph.txt", |e| e.aot_joint_graph.as_ref())),
+        Box::new(SentinelFileParser::new("inductor_post_grad_graph.txt", |e| e.inductor_post_grad_graph.as_ref())),
+        Box::new(DynamoOutputGraphParser {}),
+    ];
+    result
+}

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -1,14 +1,19 @@
 use crate::types::*;
 use std::path::PathBuf;
+use std::ffi::{OsStr, OsString};
+use std::path::Path;
+use tinytemplate::TinyTemplate;
 
 /**
  * StructuredLogParser
  * Parses a structured log and returns a vec of file outputs.
  * Implement this trait to add your own analyses.
+ *
+ * 'e is the lifetime of the individual envelope
  */
 pub trait StructuredLogParser {
     // If this returns Some value, the parser will be run on that metadata.
-    // Otherwise, it will be skipped. 'e is the lifetime of the envelope.
+    // Otherwise, it will be skipped.
     fn get_metadata<'e>(&self, e: &'e Envelope) -> Option<Metadata<'e>>;
     fn parse<'e>(&self,
         lineno: usize, // Line number from log
@@ -85,8 +90,86 @@ impl StructuredLogParser for DynamoOutputGraphParser {
     }
 }
 
+pub struct DynamoGuardParser<'t> {
+    tt: &'t TinyTemplate<'t>,
+}
+impl StructuredLogParser for DynamoGuardParser<'_> {
+    fn get_metadata<'e>(&self, e: &'e Envelope) -> Option<Metadata<'e>> {
+        e.dynamo_guards.as_ref().map(|m| Metadata::Empty(m))
+    }
+    fn parse<'e>(&self,
+            lineno: usize,
+            _metadata: Metadata<'e>,
+            _rank: Option<u32>,
+            compile_id: &Option<CompileId>,
+            payload: &str
+    ) -> anyhow::Result<ParseOutput> {
+        let filename = "dynamo_guards.html";
+        let guards = serde_json::from_str::<Vec<DynamoGuard>>(payload)?;
+        let guards_context = DynamoGuardsContext { guards };
+        let output = self.tt.render(filename, &guards_context)?;
+        simple_file_output(filename, lineno, compile_id, &output)
+    }
+}
+
+pub struct InductorOutputCodeParser;
+impl StructuredLogParser for InductorOutputCodeParser {
+    fn get_metadata<'e>(&self, e: &'e Envelope) -> Option<Metadata<'e>> {
+        e.inductor_output_code.as_ref().map(|m| Metadata::InductorOutputCode(m))
+    }
+
+    fn parse<'e>(&self,
+        lineno: usize,
+        metadata: Metadata<'e>,
+        _rank: Option<u32>,
+        compile_id: &Option<CompileId>,
+        payload: &str
+    ) -> anyhow::Result<ParseOutput> {
+        if let Metadata::InductorOutputCode(metadata) = metadata {
+            let filename = metadata
+                .filename
+                .as_ref()
+                .and_then(|p| Path::file_stem(p))
+                .map_or_else(
+                    || PathBuf::from("inductor_output_code.txt"),
+                    |stem| {
+                        let mut r = OsString::from("inductor_output_code_");
+                        r.push(stem);
+                        r.push(OsStr::new(".txt"));
+                        r.into()
+                    },
+            );
+            simple_file_output(&filename.to_string_lossy(), lineno, compile_id, payload)
+        } else {
+            Err(anyhow::anyhow!("Expected InductorOutputCode metadata"))
+        }
+    }
+}
+
+pub struct OptimizeDdpSplitChildParser;
+impl StructuredLogParser for OptimizeDdpSplitChildParser {
+    fn get_metadata<'e>(&self, e: &'e Envelope) -> Option<Metadata<'e>> {
+        e.optimize_ddp_split_child.as_ref().map(|m| Metadata::OptimizeDdpSplitChild(m))
+    }
+
+    fn parse<'e>(&self,
+        lineno: usize,
+        metadata: Metadata<'e>,
+        _rank: Option<u32>,
+        compile_id: &Option<CompileId>,
+        payload: &str
+    ) -> anyhow::Result<ParseOutput> {
+        if let Metadata::OptimizeDdpSplitChild(m) = metadata {
+            let filename = format!("optimize_ddp_split_child_{}.txt", m.name);
+            simple_file_output(&filename, lineno, compile_id, payload)
+        } else {
+            Err(anyhow::anyhow!("Expected OptimizeDdpSplitChild metadata"))
+        }
+    }
+}
+
 // Register your parser here
-pub fn all_parsers() -> Vec<Box<dyn StructuredLogParser>> {
+pub fn all_parsers<'t>(tt: &'t TinyTemplate<'t>) -> Vec<Box<dyn StructuredLogParser + 't>> {
     // We need to use Box wrappers here because vecs in Rust need to have known size
     let result : Vec<Box<dyn StructuredLogParser>> = vec![
         Box::new(SentinelFileParser::new("optimize_ddp_split_graph.txt", |e| e.optimize_ddp_split_graph.as_ref())),
@@ -95,7 +178,10 @@ pub fn all_parsers() -> Vec<Box<dyn StructuredLogParser>> {
         Box::new(SentinelFileParser::new("aot_backward_graph.txt", |e| e.aot_backward_graph.as_ref())),
         Box::new(SentinelFileParser::new("aot_joint_graph.txt", |e| e.aot_joint_graph.as_ref())),
         Box::new(SentinelFileParser::new("inductor_post_grad_graph.txt", |e| e.inductor_post_grad_graph.as_ref())),
-        Box::new(DynamoOutputGraphParser {}),
+        Box::new(DynamoOutputGraphParser),
+        Box::new(DynamoGuardParser { tt }),
+        Box::new(InductorOutputCodeParser),
+        Box::new(OptimizeDdpSplitChildParser),
     ];
     result
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -142,15 +142,15 @@ impl fmt::Display for FrameSummary {
 pub type StackSummary = Vec<FrameSummary>;
 
 #[derive(Debug, Deserialize)]
-pub struct OptimizeDdpSplitChildMetadata {
-    pub name: String,
-}
-
-#[derive(Debug, Deserialize)]
 #[serde(untagged)]
 pub enum SymInt {
     Int(i64),
     Symbol(String),
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OptimizeDdpSplitChildMetadata {
+    pub name: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -176,8 +176,8 @@ pub enum Metadata<'e> {
     DynamoOutputGraph(&'e DynamoOutputGraphMetadata),
     #[allow(dead_code)]
     DynamoStart(&'e DynamoStartMetadata),
-    #[allow(dead_code)]
     InductorOutputCode(&'e InductorOutputCodeMetadata),
+    OptimizeDdpSplitChild(&'e OptimizeDdpSplitChildMetadata),
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -10,6 +10,8 @@ use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::sync::Mutex;
 
+pub type ParseOutput = Vec<(PathBuf, String)>;
+
 pub type FxIndexMap<K, V> = IndexMap<K, V, BuildHasherDefault<FxHasher>>;
 
 pub static INTERN_TABLE: Lazy<Mutex<FxHashMap<u32, String>>> =
@@ -167,6 +169,15 @@ pub struct DynamoStartMetadata {
 #[derive(Debug, Deserialize)]
 pub struct InductorOutputCodeMetadata {
     pub filename: Option<PathBuf>,
+}
+
+pub enum Metadata<'e> {
+    Empty(&'e EmptyMetadata),
+    DynamoOutputGraph(&'e DynamoOutputGraphMetadata),
+    #[allow(dead_code)]
+    DynamoStart(&'e DynamoStartMetadata),
+    #[allow(dead_code)]
+    InductorOutputCode(&'e InductorOutputCodeMetadata),
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -99,6 +99,7 @@ pub struct Stats {
     pub fail_json: u64,
     pub fail_payload_md5: u64,
     pub fail_dynamo_guards_json: u64,
+    pub fail_parser: u64,
 }
 
 #[derive(Debug, Hash, Eq, PartialEq, Deserialize, Serialize)]
@@ -171,6 +172,7 @@ pub struct InductorOutputCodeMetadata {
     pub filename: Option<PathBuf>,
 }
 
+#[derive(Debug)]
 pub enum Metadata<'e> {
     Empty(&'e EmptyMetadata),
     DynamoOutputGraph(&'e DynamoOutputGraphMetadata),


### PR DESCRIPTION
This PR tries to generalize structured log parsers to make it easier to add new analyses for people less familiar with tlparse internals. This also makes it easier for us to have internal only analyses later. 

Basic design:

All analyses implement a trait called StructuredLogParser. To implement a new parser, simply implement the trait with:
- A function that extracts the Metadata out of the Envelope 
- A function that, given your specific Metadata and other information, produces an output vec

Afterwards, just add the trait to `all_parsers`.

I've gone ahead and implemented the simpler ones quickly and will do the rest in a bit. I know it looks like a bunch of boilerplate with lifetimes (needing to track the lifetime of the envelope each parser is associated with, for example), but honestly after this diff new additions are relatively painless. 

Test:

Run on a complicated job before and after this PR, then diff the two output directories. See no difference.

