### PR TITLE
Add failures and restarts page

### DIFF
--- a/src/templates.rs
+++ b/src/templates.rs
@@ -33,6 +33,13 @@ the indentation of the list and have a separate sub-list per sub-tree.
 {stack_trie_html | format_unescaped}
 </div>
 <div>
+{{ if num_breaks }}
+<h2> Failures and Restarts </h2>
+<p>
+Various issues may cause Dynamo to restart its analysis or give up on compilation entirely, causing graph breaks and fallbacks to eager mode.
+This run had <strong><a href="failures_and_restarts.html">{num_breaks} restart(s) and/or compilation failure(s)</a></strong>.
+</p>
+{{ endif }}
 <h2>IR dumps</h2>
 <p>
 The <strong>IR dumps</strong> collected dumped intermediate products from various points of the PT2
@@ -86,6 +93,51 @@ Build products below:
 {{ endfor }}
 </ul>
 </div>
+</body>
+</html>
+"#;
+
+pub static TEMPLATE_FAILURES_CSS : &str = r#"
+table {
+    width: 90%;
+    border-collapse: collapse;
+    margin: 20px 0;
+}
+table, th, td {
+    border: 1px solid #999;
+    padding: 10px;
+    text-align: left;
+}
+th {
+    background-color: #d3d3d3;
+    font-weight: bold;
+}
+tr:nth-child(odd) {
+    background-color: #f2f2f2;
+}
+a {
+    color: #0066cc;
+    text-decoration: none;
+}
+a:hover {
+    text-decoration: underline;
+}
+"#;
+
+pub static TEMPLATE_FAILURES_AND_RESTARTS: &str = r#"
+<html>
+<head>
+    <style>
+    {css}
+    </style>
+</head>
+<body>
+    <h1>Failures and Restarts</h1>
+    <table>
+    <tr> <th> Compile Id </th> <th> Failure Type </th> <th> Failure Description </th> <th> Failure Source (compilation failures only) </th> </tr>
+    {{ for failure in failures }}
+    <tr> <td> {failure.0 | format_unescaped} </td>{failure.1 | format_unescaped}</tr>
+    {{ endfor }}
 </body>
 </html>
 "#;

--- a/src/types.rs
+++ b/src/types.rs
@@ -175,26 +175,55 @@ pub struct InductorOutputCodeMetadata {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CompilationMetricsMetadata {
     // Other information like frame_key, co_name, etc. are already in envelope
-    cache_size: Option<u64>,
-    accumulated_cache_size: Option<u64>,
-    guard_count: Option<u64>,
-    shape_env_guard_count: Option<u64>,
-    graph_op_count: Option<u64>,
-    graph_node_count: Option<u64>,
-    graph_input_count: Option<u64>,
-    start_time: Option<f64>,
-    entire_frame_compile_time_s: Option<f64>,
-    backend_compile_time_s: Option<f64>,
-    inductor_compile_time_s: Option<f64>,
-    code_gen_time_s: Option<f64>,
-    fail_type: Option<String>,
-    fail_reason: Option<String>,
-    fail_user_frame_filename: Option<String>,
-    fail_user_frame_lineno: Option<u32>,
-    non_compliant_ops: Option<Vec<String>>,
-    compliant_custom_ops: Option<Vec<String>>,
-    restart_reasons: Option<Vec<String>>,
-    dynamo_time_before_restart_s: Option<f64>,
+    pub cache_size: Option<u64>,
+    pub accumulated_cache_size: Option<u64>,
+    pub guard_count: Option<u64>,
+    pub shape_env_guard_count: Option<u64>,
+    pub graph_op_count: Option<u64>,
+    pub graph_node_count: Option<u64>,
+    pub graph_input_count: Option<u64>,
+    pub start_time: Option<f64>,
+    pub entire_frame_compile_time_s: Option<f64>,
+    pub backend_compile_time_s: Option<f64>,
+    pub inductor_compile_time_s: Option<f64>,
+    pub code_gen_time_s: Option<f64>,
+    pub fail_type: Option<String>,
+    pub fail_reason: Option<String>,
+    pub fail_user_frame_filename: Option<String>,
+    pub fail_user_frame_lineno: Option<u32>,
+    pub non_compliant_ops: Option<Vec<String>>,
+    pub compliant_custom_ops: Option<Vec<String>>,
+    pub restart_reasons: Option<Vec<String>>,
+    pub dynamo_time_before_restart_s: Option<f64>,
+}
+
+#[derive(Debug, Serialize)]
+pub enum FailureReason {
+    Failure((String, String, String, u32)), // (failure type, failure reason, user frame filename, user frame lineno)
+    Restart(String), // restart reason
+}
+impl Display for FailureReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FailureReason::Failure((failure_type, failure_reason, user_frame_filename, user_frame_lineno)) => {
+                let failure_type = encode_text(failure_type);
+                let failure_reason = encode_text(failure_reason);
+                let user_frame_filename = encode_text(user_frame_filename);
+                write!(f, "<td><pre>{failure_type}</pre></td>
+                           <td><pre>{failure_reason}</pre></td>
+                           <td><pre>{user_frame_filename}:{user_frame_lineno}</pre></td>
+                          ")
+            }
+            FailureReason::Restart(restart_reason) => write!(f, r#"<td> RestartAnalysis </td><td><pre>{restart_reason}</pre></td><td>Not availble for restarts(yet)!</td>"#),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct RestartsAndFailuresContext {
+    // Serialized versions of (CompileId, FailureReason)
+    pub failures: Vec<(String, String)>,
+    pub css: &'static str,
 }
 
 #[derive(Debug)]
@@ -249,4 +278,5 @@ pub struct IndexContext {
     pub css: &'static str,
     pub directory: Vec<(String, Vec<PathBuf>)>,
     pub stack_trie_html: String,
+    pub num_breaks: usize,
 }

--- a/tests/inputs/comp_failure.log
+++ b/tests/inputs/comp_failure.log
@@ -1,0 +1,19 @@
+V0404 09:04:28.542000 140560297141248 torch/_logging/structured.py:19] {"str": ["/data/users/jjwu/a/pytorch/test/dynamo/test_misc.py", 0]}
+V0404 09:04:28.543000 140560297141248 torch/_logging/structured.py:19] {"str": ["/data/users/jjwu/a/pytorch/torch/_dynamo/test_case.py", 1]}
+V0404 09:04:28.543000 140560297141248 torch/_logging/structured.py:19] {"str": ["/data/users/jjwu/a/pytorch/torch/testing/_internal/common_utils.py", 2]}
+V0404 09:04:28.543000 140560297141248 torch/_logging/structured.py:19] {"str": ["/data/users/jjwu/a/pytorch-env/lib/python3.10/unittest/main.py", 3]}
+V0404 09:04:28.543000 140560297141248 torch/_logging/structured.py:19] {"str": ["/data/users/jjwu/a/pytorch-env/lib/python3.10/unittest/runner.py", 4]}
+V0404 09:04:28.543000 140560297141248 torch/_logging/structured.py:19] {"str": ["/data/users/jjwu/a/pytorch-env/lib/python3.10/unittest/suite.py", 5]}
+V0404 09:04:28.543000 140560297141248 torch/_logging/structured.py:19] {"str": ["/data/users/jjwu/a/pytorch-env/lib/python3.10/unittest/case.py", 6]}
+V0404 09:04:28.543000 140560297141248 torch/_logging/structured.py:19] {"str": ["/data/users/jjwu/a/pytorch/torch/_dynamo/eval_frame.py", 7]}
+V0404 09:04:28.543000 140560297141248 torch/_dynamo/convert_frame.py:672] {"dynamo_start": {"stack": [{"line": 10079, "name": "<module>", "filename": 0}, {"line": 41, "name": "run_tests", "filename": 1}, {"line": 1167, "name": "run_tests", "filename": 2}, {"line": 101, "name": "__init__", "filename": 3}, {"line": 271, "name": "runTests", "filename": 3}, {"line": 184, "name": "run", "filename": 4}, {"line": 84, "name": "__call__", "filename": 5}, {"line": 122, "name": "run", "filename": 5}, {"line": 84, "name": "__call__", "filename": 5}, {"line": 122, "name": "run", "filename": 5}, {"line": 650, "name": "__call__", "filename": 6}, {"line": 2868, "name": "run", "filename": 2}, {"line": 2840, "name": "_run_custom", "filename": 2}, {"line": 591, "name": "run", "filename": 6}, {"line": 549, "name": "_callTestMethod", "filename": 6}, {"line": 2741, "name": "wrapper", "filename": 2}, {"line": 9599, "name": "test_graph_break_compilation_metrics_on_failure", "filename": 0}, {"line": 410, "name": "_fn", "filename": 7}]}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}
+V0404 09:04:28.552000 140560297141248 torch/_dynamo/output_graph.py:1139] {"dynamo_output_graph": {"sizes": {"l_x_": [4, 4], "sin": [4, 4]}}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "c42a102d057a4af133785f9775eefaef"}
+	class GraphModule(torch.nn.Module):
+	    def forward(self, L_x_ : torch.Tensor):
+	        l_x_ = L_x_
+	        
+	        # File: /data/users/jjwu/a/pytorch/test/dynamo/test_misc.py:9590 in fn, code: return x.sin()
+	        sin = l_x_.sin();  l_x_ = None
+	        return (sin,)
+	        
+V0404 09:04:28.553000 140560297141248 torch/_dynamo/utils.py:685] {"compilation_metrics": {"frame_key": "1", "co_name": "fn", "co_filename": "/data/users/jjwu/a/pytorch/test/dynamo/test_misc.py", "co_firstlineno": 9589, "cache_size": 0, "accumulated_cache_size": 0, "guard_count": null, "shape_env_guard_count": null, "graph_op_count": null, "graph_node_count": null, "graph_input_count": null, "start_time": 1712246668.5434601, "entire_frame_compile_time_s": null, "backend_compile_time_s": null, "inductor_compile_time_s": null, "code_gen_time_s": null, "fail_type": "<class 'torch._dynamo.exc.BackendCompilerFailed'>", "fail_reason": "backend='broken_backend' raised:\nRuntimeError: broken backend", "fail_user_frame_filename": null, "fail_user_frame_lineno": null, "non_compliant_ops": [], "compliant_custom_ops": [], "restart_reasons": [], "dynamo_time_before_restart_s": 0.009927034378051758}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -14,6 +14,7 @@ fn test_parse_simple() {
         "0_0_0/aot_forward_graph.txt",
         "0_0_0/dynamo_output_graph.txt",
         "index.html",
+        "failures_and_restarts.html",
         "0_0_0/inductor_post_grad_graph.txt",
         "0_0_0/inductor_output_code", // This always has an output hash, so we use prefixes instead of full
         "0_0_0/dynamo_guards.html"
@@ -48,11 +49,37 @@ fn test_parse_compilation_metrics() {
         "2_0_0/dynamo_guards.html",
         "2_0_0/compilation_metrics.html",
         "index.html",
+        "failures_and_restarts.html",
     ];
     // Read the test file
     // simple.log was generated from the following:
-    // TORCH_TRACE=~/trace_logs/test python test/inductor/test_torchinductor.py  -k test_custom_op_fixed_layout_channels_last_cpu
+    // TORCH_TRACE=~/trace_logs/test python test/inductor/test_torchinductor.py  -k TORCH_TRACE=~/trace_logs/comp_metrics python test/dynamo/test_misc.py -k test_graph_break_compilation_metrics
     let path = Path::new("tests/inputs/comp_metrics.log").to_path_buf();
+    let config = tlparse::ParseConfig {
+        strict: true,
+        custom_parsers: vec![],
+    };
+    let output = tlparse::parse_path(&path, config);
+    assert!(output.is_ok());
+    let map: HashMap<PathBuf, String> = output.unwrap().into_iter().collect();
+    // Check all files are present
+    for prefix in expected_files {
+        assert!(prefix_exists(&map, prefix), "{} not found in output", prefix);
+    }
+}
+
+#[test]
+fn test_parse_compilation_failures() {
+    let expected_files = [
+        "0_0_0/dynamo_output_graph.txt",
+        "0_0_0/compilation_metrics.html",
+        "index.html",
+        "failures_and_restarts.html",
+    ];
+    // Read the test file
+    // simple.log was generated from the following:
+    // TORCH_TRACE=~/trace_logs/test python test/inductor/test_torchinductor.py  -k TORCH_TRACE=~/trace_logs/comp_metrics python test/dynamo/test_misc.py -k test_graph_break_compilation_metrics_on_failure
+    let path = Path::new("tests/inputs/comp_failure.log").to_path_buf();
     let config = tlparse::ParseConfig {
         strict: true,
         custom_parsers: vec![],


### PR DESCRIPTION
Added a global analysis which collects all of the compilation failures or graph breaks from restarting analysis into a single table. 

Updated index.html (this new section doesn't exist if there aren't any failures or graph breaks):
![image](https://github.com/ezyang/tlparse/assets/4811293/a6c65cac-c88c-46a0-aca5-2c66d9c8da6f)

Page collecting all the failures and restarts:
![image](https://github.com/ezyang/tlparse/assets/4811293/f55d0409-3fcc-4e66-8322-0cfb1bdad13c)

![image](https://github.com/ezyang/tlparse/assets/4811293/f1725756-1a90-4deb-974e-81d0ad8fa083)
