### PR TITLE
Add ordinal indicating what order products appeared in logs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub fn parse_path(path: &PathBuf, config: ParseConfig) -> anyhow::Result<ParseOu
 
     let mut expected_rank: Option<Option<u32>> = None;
 
-    let mut directory: FxIndexMap<Option<CompileId>, Vec<PathBuf>> = FxIndexMap::default();
+    let mut directory: FxIndexMap<Option<CompileId>, Vec<(PathBuf, i32)>> = FxIndexMap::default();
 
     // Store results in an output Vec<PathBuf, String>
     let mut output: Vec<(PathBuf, String)> = Vec::new();
@@ -71,6 +71,8 @@ pub fn parse_path(path: &PathBuf, config: ParseConfig) -> anyhow::Result<ParseOu
     tt.add_template("failures_and_restarts.html", TEMPLATE_FAILURES_AND_RESTARTS)?;
     tt.add_template("dynamo_guards.html", TEMPLATE_DYNAMO_GUARDS)?;
     tt.add_template("compilation_metrics.html", TEMPLATE_COMPILATION_METRICS)?;
+
+    let mut output_count = 0;
 
     let mut breaks = RestartsAndFailuresContext {
         css: TEMPLATE_FAILURES_CSS,
@@ -186,7 +188,8 @@ pub fn parse_path(path: &PathBuf, config: ParseConfig) -> anyhow::Result<ParseOu
                     Ok(results) => {
                         for (filename, out) in results {
                             output.push((filename.clone(), out));
-                            compile_directory.push(filename);
+                            compile_directory.push((filename, output_count));
+                            output_count += 1;
                         }
                     }
                     Err(err) => match parser.name() {

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -85,8 +85,8 @@ Build products below:
 {{ for compile_directory in directory }}
     <li><a id="{compile_directory.0}">{compile_directory.0}</a>
     <ul>
-        {{ for path in compile_directory.1 }}
-            <li><a href="{path}">{path}</a></li>
+        {{ for path_idx in compile_directory.1 }}
+            <li><a href="{path_idx.0}">{path_idx.0}</a> ({path_idx.1})</li>
         {{ endfor }}
     </ul>
     </li>

--- a/src/types.rs
+++ b/src/types.rs
@@ -299,7 +299,7 @@ pub struct DynamoGuardsContext {
 #[derive(Debug, Serialize)]
 pub struct IndexContext {
     pub css: &'static str,
-    pub directory: Vec<(String, Vec<PathBuf>)>,
+    pub directory: Vec<(String, Vec<(PathBuf, i32)>)>,
     pub stack_trie_html: String,
     pub num_breaks: usize,
 }


### PR DESCRIPTION
Here's what it looks like:

<img width="711" alt="image" src="https://github.com/ezyang/tlparse/assets/13564/39de771c-b997-4266-85b9-eac7903e5de0">

Notice that the backward products show up in reverse order.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>