### PR TITLE
Add --strict-compile-id for compile id presence testing

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,6 +20,10 @@ pub struct Cli {
     /// testing.
     #[arg(long)]
     strict: bool,
+    /// Return non-zero exit code if some log lines do not have associated compile id.  Used for
+    /// unit testing
+    #[arg(long)]
+    strict_compile_id: bool,
     /// Don't open browser at the end
     #[arg(long)]
     no_browser: bool,
@@ -43,6 +47,7 @@ fn main() -> anyhow::Result<()> {
 
     let config = ParseConfig {
         strict: cli.strict,
+        strict_compile_id: cli.strict_compile_id,
         custom_parsers: Vec::new(),
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ mod types;
 
 pub struct ParseConfig {
     pub strict: bool,
+    pub strict_compile_id: bool,
     pub custom_parsers: Vec<Box<dyn crate::parsers::StructuredLogParser>>,
 }
 
@@ -281,6 +282,8 @@ pub fn parse_path(path: &PathBuf, config: ParseConfig) -> anyhow::Result<ParseOu
 
     eprintln!("{:?}", stats);
 
+    let has_unknown_compile_id = directory.contains_key(&None);
+
     let index_context = IndexContext {
         css: CSS,
         directory: directory
@@ -310,6 +313,10 @@ pub fn parse_path(path: &PathBuf, config: ParseConfig) -> anyhow::Result<ParseOu
     {
         // Report something went wrong
         return Err(anyhow!("Something went wrong"));
+    }
+
+    if config.strict_compile_id && has_unknown_compile_id {
+        return Err(anyhow!("Some log entries did not have compile id"));
     }
 
     Ok(output)


### PR DESCRIPTION
Signed-off-by: Edward Z. Yang <ezyang@meta.com>