### PR TITLE
Fix links, dump all output files in compilation metrics page

### DIFF
--- a/src/templates.rs
+++ b/src/templates.rs
@@ -207,10 +207,12 @@ pub static TEMPLATE_COMPILATION_METRICS: &str = r#"
 </head>
 <body>
     <h1>Compilation Info for {compile_id}</h1>
-    <h2>Dynamo Output:</h2>
-    <object data="dynamo_output_graph.txt" style="width:80%; height:auto">
-    <a href="dynamo_output_graph.txt"> dynamo_output_graph.txt </a>
-    </object>
+    <h2>Output files:</h2>
+    <ul>
+        {{ for path_idx in output_files }}
+            <li><a href="{path_idx.0}">{path_idx.1}</a> ({path_idx.2})</li>
+        {{ endfor }}
+    </ul>
     <h2>Stack</h2>
     {stack_html | format_unescaped}
     <h2>Compile Time(seconds)</h2>

--- a/src/types.rs
+++ b/src/types.rs
@@ -240,7 +240,7 @@ pub struct ArtifactMetadata {
     pub encoding: String,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct CompilationMetricsMetadata {
     // Other information like frame_key, co_name, etc. are already in envelope
     pub cache_size: Option<u64>,
@@ -297,6 +297,7 @@ pub struct CompilationMetricsContext<'e> {
     pub compile_id: String,
     pub stack_html: String,
     pub symbolic_shape_specializations: Vec<SymbolicShapeSpecializationContext>,
+    pub output_files: &'e Vec<(String, String, i32)>,
 }
 
 #[derive(Debug, Serialize)]


### PR DESCRIPTION
With the changes to make tlparse artifacts unique, we also made it a bit harder to link to compilation artifacts from pages other than index.html. This change factors out compilationmetrics so that you can pass the entire directory into tlparse, so that each compilation metrics page wlil have all of the build products associated with that compile id directly linked. 

It also allows the failures and restarts page to link correctly to the compilation metrics page, using a similar technique.

It's a bit hacky how I derive the filenames for compilation_metrics.html, but I couldn't really come up with that good of a way otherwise. We might wanna refactor later so that each file has a unique id associated with it in the FXIndexMap or something.

<img width="1333" alt="image" src="https://github.com/ezyang/tlparse/assets/4811293/35c4a830-49ab-490e-bb65-525fc1efe13b">
