### PR TITLE
Add support for parsing chromium_events

### DIFF
--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -529,10 +529,10 @@ impl StructuredLogParser for DumpFileParser {
     }
     fn parse<'e>(
         &self,
-        lineno: usize,
+        _lineno: usize,
         metadata: Metadata<'e>,
         _rank: Option<u32>,
-        compile_id: &Option<CompileId>,
+        _compile_id: &Option<CompileId>,
         payload: &str,
     ) -> anyhow::Result<ParserResults> {
         if let Metadata::DumpFile(metadata) = metadata {

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -124,6 +124,12 @@ phase generates:
 <li>Inductor will apply some post grad FX passes, producing <code>inductor_post_grad_graph</code></li>
 <li>Inductor will perform code generation, producing the final <code>inductor_output_code</code> which will be executed at runtime.  This output is a valid Python program and can be directly run.</li>
 </ol>
+
+{{ if has_chromium_events }}
+<h2> Chromium Events </h2>
+PT2 generates <a href='chromium_events.json'>Chromium Trace Events</a> in JSON on specific events during compilation.
+You can download and view them in a tool like <a href='https://ui.perfetto.dev/'>Perfetto</a>.
+{{ endif  }}
 <p>
 Build products below:
 </p>
@@ -139,6 +145,7 @@ Build products below:
 {{ endfor }}
 </ul>
 </div>
+
 {{ if has_unknown_stack_trie }}
 <div>
 <h2>Unknown stacks</h2>

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,6 +4,7 @@ use html_escape::encode_text;
 use indexmap::IndexMap;
 use regex::Regex;
 use serde_json::Value;
+use std::io::Empty;
 
 use std::fmt::{self, Display, Write};
 use std::path::PathBuf;
@@ -452,6 +453,7 @@ pub struct Envelope {
     pub describe_tensor: Option<TensorDesc>,
     pub describe_source: Option<SourceDesc>,
     pub dump_file: Option<DumpFileMetadata>,
+    pub chromium_event: Option<EmptyMetadata>,
     #[serde(flatten)]
     pub _other: FxHashMap<String, Value>,
 }
@@ -561,6 +563,7 @@ pub struct IndexContext {
     pub has_unknown_stack_trie: bool,
     pub num_breaks: usize,
     pub custom_header_html: String,
+    pub has_chromium_events: bool,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,7 +4,7 @@ use html_escape::encode_text;
 use indexmap::IndexMap;
 use regex::Regex;
 use serde_json::Value;
-use std::io::Empty;
+
 
 use std::fmt::{self, Display, Write};
 use std::path::PathBuf;

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,7 +5,6 @@ use indexmap::IndexMap;
 use regex::Regex;
 use serde_json::Value;
 
-
 use std::fmt::{self, Display, Write};
 use std::path::PathBuf;
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -128,3 +128,27 @@ fn test_parse_artifact() {
         );
     }
 }
+
+#[test]
+fn test_parse_chromium_event() {
+    let expected_files = ["chromium_events.json", "index.html"];
+    // Read the test file
+    // simple.log was generated from the following:
+    // TORCH_TRACE=~/trace_logs/test python test/inductor/test_torchinductor.py  -k TORCH_TRACE=~/trace_logs/comp_metrics python test/dynamo/test_misc.py -k test_graph_break_compilation_metrics_on_failure
+    let path = Path::new("tests/inputs/chromium_nanogpt_cache_miss.log").to_path_buf();
+    let config = tlparse::ParseConfig {
+        strict: true,
+        ..Default::default()
+    };
+    let output = tlparse::parse_path(&path, config);
+    assert!(output.is_ok());
+    let map: HashMap<PathBuf, String> = output.unwrap().into_iter().collect();
+    // Check all files are present
+    for prefix in expected_files {
+        assert!(
+            prefix_exists(&map, prefix),
+            "{} not found in output",
+            prefix
+        );
+    }
+}


### PR DESCRIPTION
Internally we can probably `s/https://ui.perfetto.dev/<internal link>` 

For now we will have one trace for the entire tlparse: there are certain dynamo_timed events that occur outside of compile contexts i.e. cudagraphify and autotuning, which occur at "runtime", and having them in separate compile contexts actually makes the data incomplete. If this turns out to make traces too large we can reconsider some other format