### PR TITLE
Add pre_grad_graph tag

### DIFF
--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -670,6 +670,9 @@ pub fn default_parsers<'t>(
         Box::new(SentinelFileParser::new("inductor_post_grad_graph", |e| {
             e.inductor_post_grad_graph.as_ref()
         })),
+        Box::new(SentinelFileParser::new("inductor_pre_grad_graph", |e| {
+            e.inductor_pre_grad_graph.as_ref()
+        })),
         Box::new(SentinelFileParser::new("dynamo_cpp_guards_str", |e| {
             e.dynamo_cpp_guards_str.as_ref()
         })),

--- a/src/types.rs
+++ b/src/types.rs
@@ -446,6 +446,7 @@ pub struct Envelope {
     pub aot_backward_graph: Option<EmptyMetadata>,
     pub aot_inference_graph: Option<EmptyMetadata>,
     pub aot_joint_graph: Option<EmptyMetadata>,
+    pub inductor_pre_grad_graph: Option<EmptyMetadata>,
     pub inductor_post_grad_graph: Option<EmptyMetadata>,
     pub dynamo_cpp_guards_str: Option<EmptyMetadata>,
     pub inductor_output_code: Option<InductorOutputCodeMetadata>,


### PR DESCRIPTION
Add `inductor_pre_grad_graph` tag for inductor provenance tracking. It dumps the input graph to `aot_compile`.