### PR TITLE
Allow for null compliant_custom_ops and null m.non_compliant_ops

### DIFF
--- a/src/templates.rs
+++ b/src/templates.rs
@@ -270,14 +270,18 @@ pub static TEMPLATE_COMPILATION_METRICS: &str = r#"
     <p>Graph Nodes: {m.graph_node_count}</p>
     <p>Graph Inputs: {m.graph_input_count}</p>
     <h2> Custom Ops </h2>
+    {{ if m.compliant_custom_ops }}
     <p> Compliant Custom Ops:</p>
     {{ for op in m.compliant_custom_ops }}
     <li> <code> {op} </code> </li>
     {{ endfor }}
+    {{ endif }}
+    {{ if m.non_compliant_ops }}
     <p> Non-Compliant Custom Ops:</p>
     {{ for op in m.non_compliant_ops }}
     <li> <code> {op} </code> </li>
     {{ endfor }}
+    {{ endif }}
     <h2>Symbolic shape specializations</h2>
     <table>
     <tr>


### PR DESCRIPTION
Test Plan:
## Before:
```
$ tlparse -o /tmp/foo --overwrite --no-browser --strict ~/tmp/trace_logs_slarsen/dedicated_log_torch_trace_l2k873uc.log
Detected rank: None
Parser compilation_metrics failed: Encountered rendering error on line 60, column 19. Reason: Expected an array for path 'm.compliant_custom_ops' but found a non-iterable value.
  [00:00:00] [#############################################################################################################################################################################################] 133.30 KiB/133.30 KiB [22.37 MiB/s] (0s)
  Stats { ok: 62, other_rank: 0, fail_glog: 0, fail_json: 0, fail_payload_md5: 0, fail_dynamo_guards_json: 0, fail_parser: 0, unknown: 0 }                                                                                                           Stats { ok: 63, other_rank: 0, fail_glog: 0, fail_json: 0, fail_payload_md5: 0, fail_dynamo_guards_json: 0, fail_parser: 1, unknown: 0 }
2024-12-04T19:57:19.454125Z ERROR cli_log: Something went wrong
2024-12-04T19:57:19.454280Z ERROR cli_log: An error was detected, uploading logs to LogView...
...
```

## After:
```
$ /home/slarsen/local/tlparse/target/debug/tlparse -o /tmp/foo --overwrite --no-browser --strict ~/tmp/trace_logs_slarsen/dedicated_log_torch_trace_l2k873uc.log
Detected rank: None
  [00:00:00] [############################################################################################################################################################################################] 133.30 KiB/133.30 KiB [723.83 KiB/s] (0s)
  Stats { ok: 62, other_rank: 0, fail_glog: 0, fail_json: 0, fail_payload_md5: 0, fail_dynamo_guards_json: 0, fail_parser: 0, unknown: 0 }                                                                                                           Stats { ok: 63, other_rank: 0, fail_glog: 0, fail_json: 0, fail_payload_md5: 0, fail_dynamo_guards_json: 0, fail_parser: 0, unknown: 0 }
```