### PR TITLE
guard_added_fast rendering in compilation metrics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,6 +218,7 @@ pub fn parse_path(path: &PathBuf, config: ParseConfig) -> anyhow::Result<ParseOu
 
     let symbolic_shape_specialization_index: RefCell<SymbolicShapeSpecializationIndex> =
         RefCell::new(FxHashMap::default());
+    let guard_added_fast_index: RefCell<GuardAddedFastIndex> = RefCell::new(FxHashMap::default());
 
     // Store results in an output Vec<PathBuf, String>
     let mut output: Vec<(PathBuf, String)> = Vec::new();
@@ -385,6 +386,7 @@ pub fn parse_path(path: &PathBuf, config: ParseConfig) -> anyhow::Result<ParseOu
                     tt: &tt,
                     stack_index: &stack_index,
                     symbolic_shape_specialization_index: &symbolic_shape_specialization_index,
+                    guard_added_fast_index: &guard_added_fast_index,
                     output_files: &copied_directory,
                     compile_id_dir: &compile_id_dir,
                 });
@@ -465,6 +467,13 @@ pub fn parse_path(path: &PathBuf, config: ParseConfig) -> anyhow::Result<ParseOu
                 .entry(e.compile_id.clone())
                 .or_default()
                 .push(specialization);
+        }
+        if let Some(guard_added_fast) = e.guard_added_fast {
+            guard_added_fast_index
+                .borrow_mut()
+                .entry(e.compile_id.clone())
+                .or_default()
+                .push(guard_added_fast)
         }
 
         if let Some(m) = e.dynamo_start {

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -346,6 +346,7 @@ pub struct CompilationMetricsParser<'t> {
     pub tt: &'t TinyTemplate<'t>,
     pub stack_index: &'t RefCell<StackIndex>,
     pub symbolic_shape_specialization_index: &'t RefCell<SymbolicShapeSpecializationIndex>,
+    pub guard_added_fast_index: &'t RefCell<GuardAddedFastIndex>,
     pub output_files: &'t Vec<OutputFile>,
     pub compile_id_dir: &'t PathBuf,
 }
@@ -409,6 +410,18 @@ impl StructuredLogParser for CompilationMetricsParser<'_> {
                     stack_html: format_stack(&spec.stack.unwrap_or(Vec::new())),
                 })
                 .collect();
+            let guards_added_fast = self
+                .guard_added_fast_index
+                .borrow_mut()
+                .remove(&cid)
+                .unwrap_or(Vec::new())
+                .drain(..)
+                .map(|guard| GuardAddedFastContext {
+                    expr: guard.expr.unwrap_or("".to_string()),
+                    user_stack_html: format_stack(&guard.user_stack.unwrap_or(Vec::new())),
+                    stack_html: format_stack(&guard.stack.unwrap_or(Vec::new())),
+                })
+                .collect();
             let remove_prefix = |x: &String| -> String {
                 // url is X_Y_Z/<rest>. Get the rest of the string for the link
                 // on compilation metrics page
@@ -433,6 +446,7 @@ impl StructuredLogParser for CompilationMetricsParser<'_> {
                 stack_html: stack_html,
                 mini_stack_html: mini_stack_html,
                 symbolic_shape_specializations: specializations,
+                guards_added_fast: guards_added_fast,
                 output_files: &output_files,
                 compile_id_dir: &self.compile_id_dir,
                 qps: TEMPLATE_QUERY_PARAM_SCRIPT,

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -20,6 +20,12 @@ table td { vertical-align: top; }
 .status-empty { background-color: white; color: black; }
 .status-ok { background-color: green; color: white; }
 .status-break { background-color: lime; color: black; }
+summary::-webkit-details-marker { color: #00ACF3; font-size: 125%; margin-right: 2px; }
+summary:focus { outline-style: none; }
+article > details > summary { font-size: 28px; margin-top: 16px; }
+details > p { margin-left: 24px; }
+details details { margin-left: 36px; }
+details details summary { font-size: 16px; }
 "#;
 
 pub static JAVASCRIPT: &str = r#"
@@ -299,6 +305,19 @@ pub static TEMPLATE_COMPILATION_METRICS: &str = r#"
         <td>{spec.value}</td>
         <td>{spec.user_stack_html | format_unescaped}</td>
         <td>{spec.stack_html | format_unescaped}</td>
+    </tr>
+    {{ endfor }}
+    </table>
+    <h2>Guards added fast</h2>
+    <table>
+    <tr>
+        <th>Expr</th> <th>User stack</th> <th>Framework stack</th>
+    </tr>
+    {{ for g in guards_added_fast }}
+    <tr>
+        <td>{g.expr}</td>
+        <td>{g.user_stack_html | format_unescaped}</td>
+        <td>{g.stack_html | format_unescaped}</td>
     </tr>
     {{ endfor }}
     </table>

--- a/src/types.rs
+++ b/src/types.rs
@@ -18,8 +18,7 @@ pub type CompilationMetricsIndex = FxIndexMap<Option<CompileId>, Vec<Compilation
 pub type StackIndex = FxHashMap<Option<CompileId>, StackSummary>; // NB: attempt is always 0 here
 pub type SymbolicShapeSpecializationIndex =
     FxHashMap<Option<CompileId>, Vec<SymbolicShapeSpecializationMetadata>>;
-pub type GuardAddedFastIndex =
-    FxHashMap<Option<CompileId>, Vec<GuardAddedFastMetadata>>;
+pub type GuardAddedFastIndex = FxHashMap<Option<CompileId>, Vec<GuardAddedFastMetadata>>;
 
 pub type FxIndexMap<K, V> = IndexMap<K, V, BuildHasherDefault<FxHasher>>;
 


### PR DESCRIPTION
Adding rendering of "guard_added_fast" on Compilation Metrics page.

<img width="1724" alt="Screenshot 2025-01-08 at 17 37 36" src="https://github.com/user-attachments/assets/ccad73fb-a923-470c-8c02-dba14b894e66" />

Making Stack trees collapsible:



https://github.com/user-attachments/assets/df880917-5658-4508-96c4-e92518660b05



