### PR TITLE
change inductor_provenance to be on by default

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,9 +44,6 @@ pub struct Cli {
     /// For export specific logs
     #[arg(short, long)]
     export: bool,
-    /// For inductor provenance tracking highlighter
-    #[arg(short, long)]
-    inductor_provenance: bool,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -96,7 +93,6 @@ fn main() -> anyhow::Result<()> {
         verbose: cli.verbose,
         plain_text: cli.plain_text,
         export: cli.export,
-        inductor_provenance: cli.inductor_provenance,
     };
 
     let output = parse_path(&path, config)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,6 @@ pub struct ParseConfig {
     pub verbose: bool,
     pub plain_text: bool,
     pub export: bool,
-    pub inductor_provenance: bool,
 }
 
 impl Default for ParseConfig {
@@ -42,7 +41,6 @@ impl Default for ParseConfig {
             verbose: false,
             plain_text: false,
             export: false,
-            inductor_provenance: false,
         }
     }
 }
@@ -793,7 +791,10 @@ pub fn parse_path(path: &PathBuf, config: ParseConfig) -> anyhow::Result<ParseOu
         num_breaks: breaks.failures.len(),
         has_chromium_events: !chromium_events.is_empty(),
         qps: TEMPLATE_QUERY_PARAM_SCRIPT,
-        has_inductor_provenance: config.inductor_provenance,
+        has_inductor_provenance: output.iter().any(|(path, _)| {
+            path.to_string_lossy()
+                .contains("inductor_provenance_tracking_node_mappings")
+        }),
         directory_names: directory_names.clone(),
     };
     output.push((
@@ -822,57 +823,54 @@ pub fn parse_path(path: &PathBuf, config: ParseConfig) -> anyhow::Result<ParseOu
         return Err(anyhow!("Some log entries did not have compile id"));
     }
 
-    if config.inductor_provenance {
-        // Helper function to get file content for a specific directory name
-        fn get_file_content(
-            output: &[(PathBuf, String)],
-            filename_pattern: &str,
-            directory_name: &str,
-        ) -> String {
-            // get the last file that include the filename_pattern in the output
-            output
-                .iter()
-                .rev()
-                .find(|(path, _)| {
-                    path.to_string_lossy()
-                        .contains(&format!("{}/{}", directory_name, filename_pattern))
-                })
-                .map(|(_, content)| content.clone())
-                .unwrap_or_default()
-        }
+    // Helper function to get file content for a specific directory name
+    fn get_file_content(
+        output: &[(PathBuf, String)],
+        filename_pattern: &str,
+        directory_name: &str,
+    ) -> String {
+        // get the last file that include the filename_pattern in the output
+        output
+            .iter()
+            .rev()
+            .find(|(path, _)| {
+                path.to_string_lossy()
+                    .contains(&format!("{}/{}", directory_name, filename_pattern))
+            })
+            .map(|(_, content)| content.clone())
+            .unwrap_or_default()
+    }
 
-        // Generate HTML for each directory name
-        for directory_name in &directory_names {
-            let pre_grad_graph_content =
-                get_file_content(&output, "inductor_pre_grad_graph", directory_name);
-            let post_grad_graph_content =
-                get_file_content(&output, "inductor_post_grad_graph", directory_name);
-            let output_code_content =
-                get_file_content(&output, "inductor_output_code", directory_name);
-            let aot_code_content =
-                get_file_content(&output, "inductor_aot_wrapper_code", directory_name);
-            let node_mappings_content = get_file_content(
-                &output,
-                "inductor_provenance_tracking_node_mappings",
-                directory_name,
-            );
+    // Generate Inductor Provenance Tracking HTML for each directory name
+    for directory_name in &directory_names {
+        let pre_grad_graph_content =
+            get_file_content(&output, "inductor_pre_grad_graph", directory_name);
+        let post_grad_graph_content =
+            get_file_content(&output, "inductor_post_grad_graph", directory_name);
+        let output_code_content = get_file_content(&output, "inductor_output_code", directory_name);
+        let aot_code_content =
+            get_file_content(&output, "inductor_aot_wrapper_code", directory_name);
+        let node_mappings_content = get_file_content(
+            &output,
+            "inductor_provenance_tracking_node_mappings",
+            directory_name,
+        );
 
-            output.push((
-                PathBuf::from(format!("provenance_tracking_{}.html", directory_name)),
-                tt.render(
-                    "provenance_tracking.html",
-                    &ProvenanceContext {
-                        css: PROVENANCE_CSS,
-                        js: PROVENANCE_JS,
-                        pre_grad_graph_content,
-                        post_grad_graph_content,
-                        output_code_content,
-                        aot_code_content,
-                        node_mappings_content,
-                    },
-                )?,
-            ));
-        }
+        output.push((
+            PathBuf::from(format!("provenance_tracking_{}.html", directory_name)),
+            tt.render(
+                "provenance_tracking.html",
+                &ProvenanceContext {
+                    css: PROVENANCE_CSS,
+                    js: PROVENANCE_JS,
+                    pre_grad_graph_content,
+                    post_grad_graph_content,
+                    output_code_content,
+                    aot_code_content,
+                    node_mappings_content,
+                },
+            )?,
+        ));
     }
 
     Ok(output)

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -250,7 +250,6 @@ fn test_provenance_tracking() {
     // Read the test file
     let path = Path::new("tests/inputs/inductor_provenance_aot_cuda_log.txt").to_path_buf();
     let config = tlparse::ParseConfig {
-        inductor_provenance: true,
         ..Default::default()
     };
     let output = tlparse::parse_path(&path, config);


### PR DESCRIPTION
Change inductor_provenance to be on by default.

The provenance tracking html files will be generated if there's at least one `inductor_provenance_tracking_node_mappings` json.