### PR TITLE
[provenance] persist selected state for clicked line and corresponding mapped lines

### DIFF
--- a/src/provenance.css
+++ b/src/provenance.css
@@ -59,6 +59,11 @@ body {
     transition: background-color 0.2s ease;
 }
 
+.selected {
+    background-color: orange;
+    transition: background-color 0.2s ease;
+}
+
 .mapped-line {
     font-weight: bold;
 }
@@ -153,4 +158,4 @@ body {
 
 .has-match {
     font-weight: bold;
-} 
+}


### PR DESCRIPTION
### Context & User Journey

While using the provenance highlight view to check for the code mappings, currently we have the highlights on when hovering over the line, and off whenever the mouse moves out of the line.

When the source codes are non-trivial for certain generated code, the ops from pre-grad / post-grad graphs might span across more than 1 screen view. When user moves mouse over those 2 panes and want to see all the source ops by scrolling, the highlight will be gone and it gets difficult to see all the related nodes.

Also, when user moves mouse out of the window to check model code from code editors or do some other actions, the highlight will also be gone and we lose sight of the mapping info, they have to move the mouse back into the window exactly on previously hovered over line to get back the info, because otherwise the view will be scrolled to other lines when the mouse moves across other lines even only for a short moment.

### This PR
In the PR, I'm adding the "selected" state besides "highlight". The user journey would be like:

- when user clicks certain line, that line and all mapped lines will enter "selected" state. This "selected" state will stay regardless of user's mouse movement, allowing user to browse and do other inspections.
- while any line is in "selected" state, we won't do highlight on hovered lines, to prevent the view from scrolling away from current focus
- if click any already selected line (original clicked or any mapped), we'll get out of the "selected" state, highlighting and scrolling will be enabled again 