### PR TITLE
Change error message to say lineno instead of print out full json payload

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -658,7 +658,10 @@ pub fn parse_path(path: &PathBuf, config: &ParseConfig) -> anyhow::Result<ParseO
             Ok(r) => r,
             Err(err) => {
                 multi.suspend(|| {
-                    eprintln!("Failed to parse metadata JSON: {}\n{:?}", payload, err);
+                    eprintln!(
+                        "Failed to parse metadata JSON: \n{:?} on line {}",
+                        err, lineno
+                    );
                 });
                 stats.fail_json += 1;
                 write_to_shortraw(&mut shortraw_content, None, &multi, &mut stats);


### PR DESCRIPTION
This way the log is not spammed by long json