### PR TITLE
Add riscv64 build, make target list more explicit

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,20 +50,32 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [x86_64, x86, aarch64, armv7, s390x, ppc64le]
+        platform:
+          - target: x86_64-unknown-linux-gnu
+            arch: x86_64
+          - target: i686-unknown-linux-gnu
+            arch: x86
+          - target: aarch64-unknown-linux-gnu
+            arch: aarch64
+          - target: armv7-unknown-linux-gnueabihf
+            arch: armv7
+          - target: s390x-unknown-linux-gnu
+            arch: s390x
+          - target: powerpc64le-unknown-linux-gnu
+            arch: ppc64le
     steps:
       - uses: actions/checkout@v3
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          target: ${{ matrix.target }}
+          target: ${{ matrix.platform.target }}
           args: --release --out dist
           sccache: 'true'
           manylinux: auto
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-linux-${{ matrix.target }}
+          name: wheels-linux-${{ matrix.platform.arch }}
           path: dist
 
   windows:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,6 +63,8 @@ jobs:
             arch: s390x
           - target: powerpc64le-unknown-linux-gnu
             arch: ppc64le
+          - target: riscv64gc-unknown-linux-gnu
+            arch: riscv64
     steps:
       - uses: actions/checkout@v3
       - name: Build wheels


### PR DESCRIPTION
maturin supports riscv64 cross-compile, so add that to the build matrix. However, first make things more explicit about which rustc targets to use for each architecture.

From previous explorations of riscv64 builds, I've found that just specifying riscv64 as a target doesn't work, because the rustc target is actually `riscv64gc-unknown-linux-gnu`. We could simply add `riscv64gc` to the matrix, but that won't fit the patterns used for final packages, so take the time to add a `platform` list with separate `target` and `arch` fields.

Note that this is being done on behalf of the [RISE Project](https://riseproject.dev/) to improve Python ecosystem support on riscv64 platforms.

Please also note that we have a previous PR that is still open: https://github.com/meta-pytorch/tlparse/issues/107
