### PR TITLE
Support compile_ranges_endpoints field (renamed from compile_ranges_split_points)

### DIFF
--- a/src/vllm/parsers.rs
+++ b/src/vllm/parsers.rs
@@ -273,7 +273,12 @@ pub fn generate_vllm_summary(
     tt: &TinyTemplate,
     custom_header_html: &str,
 ) -> anyhow::Result<String> {
-    let config = state.config.borrow().as_ref().map(|c| normalize_config(c)).unwrap_or_default();
+    let config = state
+        .config
+        .borrow()
+        .as_ref()
+        .map(|c| normalize_config(c))
+        .unwrap_or_default();
     let dynamo_artifacts = state.build_dynamo_artifacts();
     let has_dynamo_artifacts = !dynamo_artifacts.is_empty();
     let piecewise_graph_file = state.piecewise_graph_file.borrow().clone();

--- a/src/vllm/parsers.rs
+++ b/src/vllm/parsers.rs
@@ -258,12 +258,22 @@ pub fn vllm_parsers_with_state(state: Rc<VllmState>) -> Vec<Box<dyn StructuredLo
     ]
 }
 
+fn normalize_config(config: &VllmCompilationConfig) -> VllmCompilationConfig {
+    let mut config = config.clone();
+    if config.compile_ranges_split_points.is_none() {
+        if let Some(ref endpoints) = config.compile_ranges_endpoints {
+            config.compile_ranges_split_points = Some(endpoints.clone());
+        }
+    }
+    config
+}
+
 pub fn generate_vllm_summary(
     state: &VllmState,
     tt: &TinyTemplate,
     custom_header_html: &str,
 ) -> anyhow::Result<String> {
-    let config = state.config.borrow().clone().unwrap_or_default();
+    let config = state.config.borrow().as_ref().map(|c| normalize_config(c)).unwrap_or_default();
     let dynamo_artifacts = state.build_dynamo_artifacts();
     let has_dynamo_artifacts = !dynamo_artifacts.is_empty();
     let piecewise_graph_file = state.piecewise_graph_file.borrow().clone();

--- a/src/vllm/templates.rs
+++ b/src/vllm/templates.rs
@@ -168,7 +168,7 @@ pub const VLLM_SUMMARY_TEMPLATE: &str = r#"<!DOCTYPE html>
             <tr><td><strong>CUDAGraph Mode</strong></td><td>{config.cudagraph_mode}</td></tr>
             <tr><td><strong>Use Inductor Graph Partition</strong></td><td>{config.use_inductor_graph_partition}</td></tr>
             <tr><td><strong>Compile Sizes</strong></td><td>{config.compile_sizes}</td></tr>
-            <tr><td><strong>Compile Ranges Split Points</strong></td><td>{config.compile_ranges_split_points}</td></tr>
+            <tr><td><strong>Compile Ranges Endpoints</strong></td><td>{config.compile_ranges_split_points}</td></tr>
             <tr><td><strong>Inductor Passes</strong></td><td>{config.inductor_passes}</td></tr>
             <tr><td><strong>Enabled Passes</strong></td><td>{config.enabled_passes}</td></tr>
             <tr><td><strong>Dynamic Shapes Type</strong></td><td>{config.dynamic_shapes_type}</td></tr>

--- a/src/vllm/types.rs
+++ b/src/vllm/types.rs
@@ -10,7 +10,9 @@ pub struct VllmCompilationConfig {
     pub splitting_ops: Option<String>,
     pub cudagraph_mode: Option<String>,
     pub compile_sizes: Option<String>,
+    /// Accepts both old name (compile_ranges_split_points) and new name (compile_ranges_endpoints).
     pub compile_ranges_split_points: Option<String>,
+    pub compile_ranges_endpoints: Option<String>,
     pub use_inductor_graph_partition: Option<bool>,
     pub inductor_passes: Option<String>,
     pub enabled_passes: Option<String>,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #178
* #177
* #176
* __->__ #175

Add backwards-compatible support for the new compile_ranges_endpoints
config field while preserving the old compile_ranges_split_points name.
normalize_config copies endpoints into split_points for template display.

Authored with claude