### PR TITLE
Add subgraph name to tlparse for regional inductor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /tl_out
 *.log
 !/tests/inputs/*.log
+.claude/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,7 @@ fn add_file_output(
     compile_directory: &mut Vec<OutputFile>,
     output_count: &mut i32,
     vllm_state: &vllm::VllmState,
+    subgraph_name: &Option<String>,
 ) {
     let is_stack_traces = is_stack_traces_file(&filename);
     let maybe_content = if is_stack_traces {
@@ -158,6 +159,8 @@ fn add_file_output(
         number: *output_count,
         suffix: suffix,
         readable_url,
+        starts_group: false,
+        group_name: subgraph_name.clone().unwrap_or_default(),
     });
     *output_count += 1;
 }
@@ -240,6 +243,7 @@ fn run_parser<'t>(
                                 compile_directory,
                                 output_count,
                                 vllm_state,
+                                &e.subgraph_name,
                             );
                         }
                         ParserOutput::GlobalFile(filename, out) => {
@@ -250,6 +254,7 @@ fn run_parser<'t>(
                                 compile_directory,
                                 output_count,
                                 vllm_state,
+                                &e.subgraph_name,
                             );
                         }
                         ParserOutput::PayloadFile(raw_filename) => {
@@ -264,6 +269,7 @@ fn run_parser<'t>(
                                 compile_directory,
                                 output_count,
                                 vllm_state,
+                                &e.subgraph_name,
                             );
                         }
                         ParserOutput::PayloadReformatFile(raw_filename, formatter) => {
@@ -280,6 +286,7 @@ fn run_parser<'t>(
                                         compile_directory,
                                         output_count,
                                         vllm_state,
+                                        &e.subgraph_name,
                                     );
                                 }
                                 Err(err) => {
@@ -301,6 +308,8 @@ fn run_parser<'t>(
                                 number: *output_count,
                                 suffix: "".to_string(),
                                 readable_url: None,
+                                starts_group: false,
+                                group_name: e.subgraph_name.clone().unwrap_or_default(),
                             });
                             *output_count += 1;
                         }
@@ -857,6 +866,7 @@ pub fn parse_path(path: &PathBuf, config: &ParseConfig) -> anyhow::Result<ParseO
                                         compile_directory,
                                         &mut output_count,
                                         &vllm_state,
+                                        &e.subgraph_name,
                                     );
                                 }
                                 ParserOutput::GlobalFile(filename, out) => {
@@ -867,6 +877,7 @@ pub fn parse_path(path: &PathBuf, config: &ParseConfig) -> anyhow::Result<ParseO
                                         compile_directory,
                                         &mut output_count,
                                         &vllm_state,
+                                        &e.subgraph_name,
                                     );
                                 }
                                 ParserOutput::PayloadFile(raw_filename) => {
@@ -881,6 +892,7 @@ pub fn parse_path(path: &PathBuf, config: &ParseConfig) -> anyhow::Result<ParseO
                                         compile_directory,
                                         &mut output_count,
                                         &vllm_state,
+                                        &e.subgraph_name,
                                     );
                                 }
                                 ParserOutput::PayloadReformatFile(raw_filename, formatter) => {
@@ -897,6 +909,7 @@ pub fn parse_path(path: &PathBuf, config: &ParseConfig) -> anyhow::Result<ParseO
                                                 compile_directory,
                                                 &mut output_count,
                                                 &vllm_state,
+                                                &e.subgraph_name,
                                             );
                                         }
                                         Err(err) => {
@@ -918,6 +931,8 @@ pub fn parse_path(path: &PathBuf, config: &ParseConfig) -> anyhow::Result<ParseO
                                         number: output_count,
                                         suffix: "".to_string(),
                                         readable_url: None,
+                                        starts_group: false,
+                                        group_name: e.subgraph_name.clone().unwrap_or_default(),
                                     });
                                     output_count += 1;
                                 }
@@ -1261,6 +1276,16 @@ pub fn parse_path(path: &PathBuf, config: &ParseConfig) -> anyhow::Result<ParseO
     }
 
     let has_unknown_compile_id = directory.contains_key(&None);
+
+    for files in directory.values_mut() {
+        let mut prev_group = String::new();
+        for file in files.iter_mut() {
+            if file.group_name != prev_group {
+                file.starts_group = true;
+                prev_group = file.group_name.clone();
+            }
+        }
+    }
 
     let directory_names: Vec<String> = directory
         .iter()

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -593,6 +593,8 @@ impl StructuredLogParser for CompilationMetricsParser<'_> {
                     number: o.number.clone(),
                     suffix: o.suffix.clone(),
                     readable_url: o.readable_url.as_ref().map(|u| remove_prefix(u)),
+                    starts_group: o.starts_group,
+                    group_name: o.group_name.clone(),
                 })
                 .collect();
             let extra_metrics: Vec<ExtraMetricContext> = m

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -195,6 +195,7 @@ Build products below:
     <li><a id="{compile_directory.0}">{compile_directory.0}</a>
     <ul>
         {{ for path_idx in compile_directory.1 }}
+            {{ if path_idx.starts_group }}<li style="margin-top: 8px;">{{ if path_idx.group_name }}Subgraph Name: {path_idx.group_name}{{ endif }}</li>{{ endif }}
             <li><a href="{path_idx.url}">{path_idx.name}</a>{{ if path_idx.readable_url }} (<a href="{path_idx.readable_url}">readable_html</a>){{ endif }} {path_idx.suffix} ({path_idx.number})</li>
         {{ endfor }}
     </ul>

--- a/src/types.rs
+++ b/src/types.rs
@@ -636,6 +636,10 @@ pub struct OutputFile {
     pub suffix: String,
     /// URL to a human-readable HTML version of inductor_provenance_tracking_kernel_stack_traces.json
     pub readable_url: Option<String>,
+    #[serde(default)]
+    pub starts_group: bool,
+    #[serde(default)]
+    pub group_name: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -773,6 +777,7 @@ pub struct Envelope {
     pub rank: Option<u32>,
     #[serde(flatten)]
     pub compile_id: Option<CompileId>,
+    pub subgraph_name: Option<String>,
     #[serde(default)]
     pub has_payload: Option<String>,
     pub stack: Option<StackSummary>,

--- a/tests/inputs/subgraph_name.log
+++ b/tests/inputs/subgraph_name.log
@@ -1,0 +1,6 @@
+V0429 16:46:26.856000 3930665 /torch/_logging/structured.py:28] {"artifact": {"name": "dynamo_output_graph", "encoding": "string"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "8b4a69a00ac3b2850d14ad15b66d77ed"}
+	test payload no subgraph
+V0429 16:46:27.745000 3930665 /torch/_inductor/compile_fx.py:1313] {"artifact": {"name": "fx_graph_runnable", "encoding": "string"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "subgraph_name": "repeated_subgraph0", "has_payload": "dcffdffe5e74fe67eaf327b0453e379a"}
+	test payload subgraph A
+V0429 16:46:29.604000 3930665 /torch/_inductor/compile_fx.py:1313] {"artifact": {"name": "fx_graph_runnable", "encoding": "string"}, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "subgraph_name": "partitioned_bw_subgraph_1_0", "has_payload": "13e1309b0f53ad9d570fda42091e0569"}
+	test payload subgraph B

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3345,3 +3345,34 @@ fn test_cli_no_overwrite_fails() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[test]
+fn test_subgraph_name_grouping() {
+    let path = Path::new("tests/inputs/subgraph_name.log").to_path_buf();
+    let config = ParseConfig::default();
+    let output = tlparse::parse_path(&path, &config);
+    assert!(output.is_ok());
+    let map: HashMap<PathBuf, String> = output.unwrap().into_iter().collect();
+
+    // All files should be flat in -_0_0_0/ (no subgraph subdirectories)
+    assert!(prefix_exists(&map, "-_0_0_0/dynamo_output_graph"));
+    assert!(prefix_exists(&map, "-_0_0_0/fx_graph_runnable"));
+
+    // No files should be nested under subgraph subdirectories
+    assert!(
+        !map.keys()
+            .any(|k| k.to_str().unwrap_or("").contains("repeated_subgraph0/")),
+        "files should not be in subgraph subdirectories"
+    );
+
+    // Index should contain subgraph group headers
+    let index = &map[&PathBuf::from("index.html")];
+    assert!(
+        index.contains("Subgraph Name: repeated_subgraph0"),
+        "index should contain repeated_subgraph0 group header"
+    );
+    assert!(
+        index.contains("Subgraph Name: partitioned_bw_subgraph_1_0"),
+        "index should contain partitioned_bw_subgraph_1_0 group header"
+    );
+}


### PR DESCRIPTION
## Summary

- Add support for the `subgraph_name` field in PyTorch structured logs (used by regional inductor for repeated subgraphs, partitioned forward/backward subgraphs, etc.)
- When `subgraph_name` is present on a log entry, the HTML index renders a "Subgraph Name: ..." group header to visually separate artifacts by subgraph
- Files remain flat in the compile ID directory (no new subdirectories)

## Changes

**`src/types.rs`** — Add `subgraph_name: Option<String>` to `Envelope` so serde deserializes the new field. Add `starts_group` and `group_name` to `OutputFile` for rendering group separators.

**`src/lib.rs`** — Thread the envelope's `subgraph_name` through `add_file_output` into each `OutputFile`. After all parsing, compute group boundaries by detecting when consecutive files have different `group_name` values and setting `starts_group = true`.

**`src/parsers.rs`** — Copy the two new `OutputFile` fields in the `CompilationMetricsParser` output remapping.

**`src/templates.rs`** — Render a `<li>` group header with top margin when `starts_group` is true.

**`tests/inputs/subgraph_name.log`** — Minimal 6-line test log with 3 artifacts: one with no subgraph, one with `repeated_subgraph0`, one with `partitioned_bw_subgraph_1_0`.

**`tests/integration_test.rs`** — `test_subgraph_name_grouping`: verifies files are flat (no subgraph subdirectories), and the index HTML contains the expected group headers.

## Test plan

- [x] `cargo test` — all 64 tests pass (63 existing + 1 new)
- [x] Manual run on a real log with subgraph_name entries confirms group headers appear in index.html



Example output:

For annotation based regional inductor: 

<img width="821" height="779" alt="Screenshot 2026-04-29 at 5 51 07 PM" src="https://github.com/user-attachments/assets/214dcd2f-26c5-41da-94e4-b22873e13470" />

For invoke_subgraph based regional inductor:

<img width="726" height="591" alt="Screenshot 2026-04-29 at 5 51 45 PM" src="https://github.com/user-attachments/assets/f2f828be-4653-4021-a3d9-d07e964d940a" />
