### PR TITLE
fix: deduplicate graph breaks in tlparse summary

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -652,6 +652,7 @@ pub fn parse_path(path: &PathBuf, config: &ParseConfig) -> anyhow::Result<ParseO
         failures: Vec::new(),
         qps: TEMPLATE_QUERY_PARAM_SCRIPT,
     };
+    let mut distinct_graph_breaks: Vec<String> = Vec::new();
 
     let mut export_failures: Vec<ExportFailure> = Vec::new();
 
@@ -966,6 +967,9 @@ pub fn parse_path(path: &PathBuf, config: &ParseConfig) -> anyhow::Result<ParseO
                         id.clone(),
                         format!("{}", FailureReason::Restart(restart.clone())),
                     ));
+                    if !distinct_graph_breaks.contains(restart) {
+                        distinct_graph_breaks.push(restart.clone());
+                    }
                 }
             }
             if let Some(f) = m.fail_type.as_ref() {
@@ -1300,6 +1304,7 @@ pub fn parse_path(path: &PathBuf, config: &ParseConfig) -> anyhow::Result<ParseO
     ));
 
     // Generate traditional tlparse index
+    let has_distinct_graph_breaks = !distinct_graph_breaks.is_empty();
     let index_context = IndexContext {
         css: CSS,
         javascript: JAVASCRIPT,
@@ -1320,6 +1325,8 @@ pub fn parse_path(path: &PathBuf, config: &ParseConfig) -> anyhow::Result<ParseO
         qps: TEMPLATE_QUERY_PARAM_SCRIPT,
         has_inductor_provenance: config.inductor_provenance,
         directory_names: directory_names.clone(),
+        distinct_graph_breaks,
+        has_distinct_graph_breaks,
     };
     let tlparse_index_html = tt.render("index.html", &index_context)?;
 

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -135,6 +135,17 @@ Various issues may cause Dynamo to restart its analysis or give up on compilatio
 This run had <strong><a href="failures_and_restarts.html">{num_breaks} restart(s) and/or compilation failure(s)</a></strong>.
 </p>
 {{ endif }}
+{{ if has_distinct_graph_breaks }}
+<h2> Distinct Graph Breaks </h2>
+<p>
+Below is a summary of <strong>distinct graph break reasons</strong> across all compilations, with each unique break shown only once:
+</p>
+<ul>
+{{ for reason in distinct_graph_breaks }}
+  <li><code>{reason}</code></li>
+{{ endfor }}
+</ul>
+{{ endif }}
 <h2>IR dumps</h2>
 <p>
 The <strong>IR dumps</strong> collected dumped intermediate products from various points of the PT2

--- a/src/types.rs
+++ b/src/types.rs
@@ -934,6 +934,8 @@ pub struct IndexContext {
     pub qps: &'static str,
     pub has_inductor_provenance: bool,
     pub directory_names: Vec<String>,
+    pub distinct_graph_breaks: Vec<String>,
+    pub has_distinct_graph_breaks: bool,
 }
 
 #[derive(Debug, Serialize)]


### PR DESCRIPTION
## Summary

Adds a **Distinct Graph Breaks** section to the tlparse HTML index page that shows each unique graph break reason only once, removing duplicate entries that make it hard for end users to identify which graph breaks need fixing.

## Problem

Previously, tlparse listed every graph break occurrence including duplicates in the Failures and Restarts section. Users had to manually sift through repeated identical break reasons to understand what actually needs fixing.

## Solution

This change collects distinct graph break reasons from restart entries (using deduplication via Vec::contains) and displays them in a new dedicated 'Distinct Graph Breaks' section at the top of the index page. The existing Failures and Restarts section is preserved unchanged for detailed inspection.

### Changes

- **src/lib.rs**: Added distinct_graph_breaks collection with deduplication logic
- **src/types.rs**: Added distinct_graph_breaks and has_distinct_graph_breaks fields to IndexContext
- **src/templates.rs**: Added template section for rendering the distinct graph breaks summary

Fixes pytorch/pytorch#153669

## Test Plan

- cargo check passes
- The change is purely additive - no existing functionality is modified

PR authored with AI assistant.